### PR TITLE
[feat] teamID로 팀원 이름, 프로필 사진 모두 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
@@ -1,0 +1,44 @@
+package com.o1b4.serverquota.controller;
+
+import com.o1b4.serverquota.dto.response.TeamMemberDTO;
+import com.o1b4.serverquota.response.ResponseMessage;
+import com.o1b4.serverquota.service.TeamService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/teams")
+public class TeamController {
+    private final TeamService teamService;
+
+    public TeamController(TeamService teamService) {
+        this.teamService = teamService;
+    }
+
+    // teamId로 team에 속한 User 이름, 프로필 사진 조회
+    @GetMapping("/users/{teamId}")
+    public ResponseEntity<ResponseMessage> findTeamMembers(@PathVariable long teamId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        List<TeamMemberDTO> teamMembers = teamService.findTeamMembersByTeamId(teamId);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("teamMembers", teamMembers);
+
+        ResponseMessage responseMessage = new ResponseMessage(HttpStatus.OK, "조회 성공", responseMap);
+
+        return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
+    }
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/TeamMemberDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/TeamMemberDTO.java
@@ -1,0 +1,20 @@
+package com.o1b4.serverquota.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class TeamMemberDTO {
+
+    private String userName;
+
+    private String userProfileImage;
+
+    @Builder
+    public TeamMemberDTO(String userName, String userProfileImage) {
+        this.userName = userName;
+        this.userProfileImage = userProfileImage;
+    }
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/BelongTeamRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/BelongTeamRepository.java
@@ -3,10 +3,13 @@ package com.o1b4.serverquota.repository;
 import com.o1b4.serverquota.entity.BelongTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BelongTeamRepository extends JpaRepository<BelongTeam, Long> {
 
     // userId로 소속되어 있는 팀 찾기
     Optional<BelongTeam> findFirstByUserId(Long userId);
- }
+
+    List<BelongTeam> findByTeamId(long teamId);
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
@@ -1,22 +1,28 @@
 package com.o1b4.serverquota.service;
 
 import com.o1b4.serverquota.dto.response.MainTeamDTO;
+import com.o1b4.serverquota.dto.response.TeamMemberDTO;
 import com.o1b4.serverquota.entity.BelongTeam;
 import com.o1b4.serverquota.entity.Team;
 import com.o1b4.serverquota.exception.CustomApiException;
 import com.o1b4.serverquota.repository.BelongTeamRepository;
 import com.o1b4.serverquota.repository.TeamRepository;
+import com.o1b4.serverquota.repository.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class TeamService {
     private final TeamRepository teamRepository;
-
+    private final UserRepository userRepository;
     private final BelongTeamRepository belongTeamRepository;
 
-    public TeamService(TeamRepository teamRepository, BelongTeamRepository belongTeamRepository) {
+    public TeamService(TeamRepository teamRepository, UserRepository userRepository, BelongTeamRepository belongTeamRepository) {
         this.teamRepository = teamRepository;
+        this.userRepository = userRepository;
         this.belongTeamRepository = belongTeamRepository;
     }
 
@@ -34,5 +40,29 @@ public class TeamService {
                 .teamUrl(team.getTeamUrl())
                 .role(String.valueOf(belongTeam.getUserRole()))
                 .build();
+    }
+
+    public List<TeamMemberDTO> findTeamMembersByTeamId(long teamId) {
+
+        // teamId를 받아 belongTeam 매핑 테이블 조회
+        List<BelongTeam> belongTeams = belongTeamRepository.findByTeamId(teamId);
+
+        // list에 해당하는 room들 DTO 매핑
+        return belongTeams.stream()
+                .map(
+                        belongTeam -> TeamMemberDTO.builder()
+                        .userName(
+                                userRepository.findUserByUserId(belongTeam.getUserId())
+                                .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "회원을 조회할 수 없습니다."))
+                                .getUserName()
+                        )
+                        .userProfileImage(
+                                userRepository.findUserByUserId(belongTeam.getUserId())
+                                .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "회원을 조회할 수 없습니다."))
+                                .getUserProfileImage()
+                        )
+                        .build()
+                )
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
ex) feat/find_users_name_profile_by_user

### issue
https://github.com/O1B4/Server-Quota/issues/4#issue-1944018791

### ❓ 변경 사항
teamID로 해당 팀에 해당하는 팀원 이름, 프로필 사진 모두 조회

### 🧪 테스트 결과
![image](https://github.com/O1B4/Server-Quota/assets/114378724/dd00a091-3798-4443-b8c2-c62990ebf7a0)

