### PR TITLE
[feat] userId로 소속된 team 이름 모두 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
@@ -41,4 +41,19 @@ public class TeamController {
 
         return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
     }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ResponseMessage> findAllBelongTeams(@PathVariable long userId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        List<String> Teams = teamService.findTeamsByUserId(userId);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("Teams", Teams);
+
+        ResponseMessage responseMessage = new ResponseMessage(HttpStatus.OK, "조회 성공", responseMap);
+
+        return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
+    }
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/BelongTeamRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/BelongTeamRepository.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 public interface BelongTeamRepository extends JpaRepository<BelongTeam, Long> {
 
     // userId로 소속되어 있는 팀 찾기
-    Optional<BelongTeam> findFirstByUserId(Long userId);
+    Optional<BelongTeam> findFirstByUserId(long userId);
 
     List<BelongTeam> findByTeamId(long teamId);
+
+    List<BelongTeam> findByUserId(long userId);
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/TeamRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/TeamRepository.java
@@ -4,8 +4,12 @@ import com.o1b4.serverquota.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     // teamId에 속한 Team 하나만 조회 쿼리문
     Team findFirstByTeamId(@Param("teamid") long teamId);
+
+    Optional<Team> findTeamByTeamId(Long user);
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
@@ -65,4 +65,23 @@ public class TeamService {
                 )
                 .collect(Collectors.toList());
     }
+
+    public List<String> findTeamsByUserId(long userId) {
+
+        List<BelongTeam> belongTeams = belongTeamRepository.findByUserId(userId);
+
+        // userID에 해당하는 Team의 id list
+        List<Long> teamIdList = belongTeams.stream()
+                .map(BelongTeam::getTeamId)
+                .collect(Collectors.toList());
+
+        // 팀 이름 리스트
+        return teamIdList.stream()
+                .map(
+                        teamId -> teamRepository.findTeamByTeamId(teamId)
+                                .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "해당 팀을 찾지 못했습니다."))
+                                .getTeamName()
+                )
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
ex) feat/find_team_names_by_user_id -> main

### issue
https://github.com/O1B4/Server-Quota/issues/5#issue-1944031776

### ❓ 변경 사항
해당 user의 user ID를 이용하여 user가 속해있는 모든 팀의 이름 리스트 조회

### 🧪 테스트 결과
![image](https://github.com/O1B4/Server-Quota/assets/114378724/94693575-432c-4ec8-932b-c2118526db9b)
