### PR TITLE
roomID로 room의 간단한 정보 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/controller/RoomController.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/controller/RoomController.java
@@ -2,6 +2,7 @@ package com.o1b4.serverquota.controller;
 
 import com.o1b4.serverquota.dto.response.MainReservationRoomDTO;
 import com.o1b4.serverquota.dto.response.ReservationRoomDTO;
+import com.o1b4.serverquota.dto.response.SimpleReservationRoomDTO;
 import com.o1b4.serverquota.response.ResponseMessage;
 import com.o1b4.serverquota.service.RoomService;
 import org.springframework.http.HttpHeaders;
@@ -68,6 +69,21 @@ public class RoomController {
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("isUrlUsable", isUrlUsable);
+
+        ResponseMessage responseMessage = new ResponseMessage(HttpStatus.OK, "조회 성공", responseMap);
+
+        return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
+    }
+
+    @GetMapping("/simple/{roomId}")
+    public ResponseEntity<ResponseMessage> findSimpleReservationRoom(@PathVariable long roomId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        SimpleReservationRoomDTO room  = roomService.findSimpleReservationRoom(roomId);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("reservationRoom", room);
 
         ResponseMessage responseMessage = new ResponseMessage(HttpStatus.OK, "조회 성공", responseMap);
 

--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/SimpleReservationRoomDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/SimpleReservationRoomDTO.java
@@ -1,0 +1,30 @@
+package com.o1b4.serverquota.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class SimpleReservationRoomDTO {
+
+    private String advisorName;
+
+    private String reservationName;
+
+    private int duration;
+
+    private String meetingLocation;
+
+    private String roomDescription;
+
+
+    @Builder
+    public SimpleReservationRoomDTO(String advisorName, String reservationName, int duration, String meetingLocation, String roomDescription) {
+        this.advisorName = advisorName;
+        this.reservationName = reservationName;
+        this.duration = duration;
+        this.meetingLocation = meetingLocation;
+        this.roomDescription = roomDescription;
+    }
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/RoomRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/RoomRepository.java
@@ -5,13 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<ReservationRoom, Long> {
 
     List<ReservationRoom> findReservationRoomsByTeamId(long teamId);
 
-    ReservationRoom findReservationRoomByRoomId(long roomId);
+    Optional<ReservationRoom> findReservationRoomByRoomId(long roomId);
 
     Boolean existsByRoomUrl(String roomUrl);
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/RoomService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/RoomService.java
@@ -6,13 +6,16 @@ import com.o1b4.serverquota.dto.response.ReservationRoomDTO;
 import com.o1b4.serverquota.entity.AvailableTime;
 import com.o1b4.serverquota.entity.NotAvailableDate;
 import com.o1b4.serverquota.entity.ReservationRoom;
+import com.o1b4.serverquota.exception.CustomApiException;
 import com.o1b4.serverquota.repository.AvailableTimeRepository;
 import com.o1b4.serverquota.repository.NotAvailableDateRepository;
 import com.o1b4.serverquota.repository.RoomRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -52,7 +55,9 @@ public class RoomService {
 
     public ReservationRoomDTO findReservationRoomByRoomId(long roomId) {
 
-        ReservationRoom room = roomRepository.findReservationRoomByRoomId(roomId);
+        ReservationRoom room = roomRepository.findReservationRoomByRoomId(roomId)
+                .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "해당 예약 룸은 존재하지 않습니다!"));
+
         List<AvailableTime> availableTimes = availableTimeRepository.getAvailableTimesByRoomId(roomId);
         List<NotAvailableDate> NotAvailableDates = notAvailableDateRepository.findAllByRoomId(roomId);
 


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
ex) feat/find_simple_room_info_by_room_id -> main

### issue


### ❓ 변경 사항
roomID로 room의 간소화된 정보 조회
(예약 페이지에서 간소화된 room 정보 필요)

NPE 대신 custom API exception 띄울 수 있도록 수정

### 🧪 테스트 결과
```JSON
{
    "httpStatus": "OK",
    "message": "조회 성공",
    "results": {
        "reservationRoom": {
            "advisorName": "quotiume",
            "reservationName": "first 예약 룸",
            "duration": 1,
            "meetingLocation": "이디야",
            "roomDescription": "room에 대한 설명"
        }
    }
}
```