### PR TITLE
[feat] roomId로 Reservation 정보 모두 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/controller/ReservationController.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/controller/ReservationController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -41,4 +42,20 @@ public class ReservationController {
 
         return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
     }
+
+    @GetMapping("/room/{roomId}")
+    public ResponseEntity<ResponseMessage> findReservations(@PathVariable long roomId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        List<ReservationDTO> reservations  = reservationService.findReservations(roomId);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("reservations", reservations);
+
+        ResponseMessage responseMessage = new ResponseMessage(HttpStatus.OK, "조회 성공", responseMap);
+
+        return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
+    }
+
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/entity/Reservation.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/entity/Reservation.java
@@ -22,10 +22,10 @@ public class Reservation {
     private Long reservId;
 
     @Column(name = "roomid")
-    private long roomid;
+    private long roomId;
 
     @Column(name = "userid")
-    private long userid;
+    private long userId;
 
     @Column(name = "reservdate", nullable = false)
     private LocalDate reservDate;

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/ReservationRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/ReservationRepository.java
@@ -3,9 +3,12 @@ package com.o1b4.serverquota.repository;
 import com.o1b4.serverquota.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     Optional<Reservation> findReservationByReservId(long ReservId);
+
+    List<Reservation> findReservationByRoomId(long roomId);
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/ReservationService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/ReservationService.java
@@ -9,6 +9,9 @@ import com.o1b4.serverquota.repository.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class ReservationService {
 
@@ -27,7 +30,7 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findReservationByReservId(reservId)
                 .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "조회된 예약이 없습니다."));
 
-        User user = userRepository.findUserByUserId(reservation.getUserid())
+        User user = userRepository.findUserByUserId(reservation.getUserId())
                 .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "예약을 만든 회원이 없습니다."));
 
         return ReservationDTO.builder()
@@ -38,5 +41,26 @@ public class ReservationService {
                 .userName(user.getUserName())
                 .reservMemo(reservation.getReservMemo())
                 .build();
+    }
+
+    public List<ReservationDTO> findReservations(long roomId) {
+        List<Reservation> reservations = reservationRepository.findReservationByRoomId(roomId);
+
+        return reservations.stream()
+                .map(
+                        reservation -> ReservationDTO.builder()
+                                .reservDate(reservation.getReservDate())
+                                .reservTime(reservation.getReservTime())
+                                .reservEmail(reservation.getReservEmail())
+                                .reservName(reservation.getReservName())
+                                .userName(
+                                        userRepository.findUserByUserId(reservation.getUserId())
+                                                        .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "예약을 만든 회원이 없습니다."))
+                                                        .getUserName()
+                                        )
+                                .reservMemo(reservation.getReservMemo())
+                                        .build()
+                )
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
ex) feat/find_reservations_by_room_id -> main

### issue


### ❓ 변경 사항
roomID로 조회하여 해당 room을 통해 예약한 reservation 모두 조회

### 🧪 테스트 결과
``` JSON
{
    "httpStatus": "OK",
    "message": "조회 성공",
    "results": {
        "reservations": [
            {
                "reservDate": "2023-01-01",
                "reservTime": "11:00:00",
                "userName": "quotiume",
                "reservName": "예약 이름 1",
                "reservEmail": "aaa@gmail.com 설명란에 적어놓은 email",
                "reservMemo": "예약 설명 1"
            },
            {
                "reservDate": "2023-11-11",
                "reservTime": "13:00:00",
                "userName": "두번째 사람",
                "reservName": "예약 이름 2",
                "reservEmail": "aadsaa@gmail.com 설명란에 적어놓은 email",
                "reservMemo": "예약 설명 2"
            }
        ]
    }
}
```
