### PR TITLE
[feat] 팀 초대

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/controller/TeamController.java
@@ -1,10 +1,9 @@
 package com.o1b4.serverquota.controller;
 
 import com.o1b4.serverquota.dto.request.CreateTeamDTO;
-import com.o1b4.serverquota.dto.request.RegisterMemberDTO;
+import com.o1b4.serverquota.dto.request.InvitationDTO;
 import com.o1b4.serverquota.dto.response.RolelessMainTeamDTO;
 import com.o1b4.serverquota.dto.response.TeamMemberDTO;
-import com.o1b4.serverquota.entity.Team;
 import com.o1b4.serverquota.exception.CustomApiException;
 import com.o1b4.serverquota.response.ResponseMessage;
 import com.o1b4.serverquota.service.TeamService;
@@ -126,4 +125,27 @@ public class TeamController {
         return new ResponseEntity<>(responseMessage, headers, responseMessage.getHttpStatus());
     }
 
+    @PostMapping("/invitation")
+    public ResponseEntity<ResponseMessage> teamInvitation(@RequestBody InvitationDTO invitation) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        ResponseMessage responseMessage = new ResponseMessage();
+
+        Map<String, Object> responseMap = new HashMap<>();
+
+        try {
+            String role = String.valueOf(teamService.teamInvitation(invitation));
+            responseMessage.setMessage("유저 초대 성공");
+            responseMessage.setHttpStatus(HttpStatus.OK);
+
+            responseMap.put("userRole", role);
+
+        } catch (CustomApiException e) {
+            responseMessage.setMessage(e.getMessage());
+            responseMessage.setHttpStatus(e.getHttpStatus());
+        }
+
+        return new ResponseEntity<>(responseMessage, headers, responseMessage.getHttpStatus());
+    }
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/request/InvitationDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/request/InvitationDTO.java
@@ -1,0 +1,19 @@
+package com.o1b4.serverquota.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationDTO {
+
+    private long teamId;
+
+    private String email;
+
+    // 원래는 isAdvisor 였으나 @Getter 문제로 is 삭제
+    private boolean advisor;
+
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/InvitedUserDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/InvitedUserDTO.java
@@ -1,0 +1,16 @@
+package com.o1b4.serverquota.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class InvitedUserDTO {
+    private String userName;
+
+    private Long teamName;
+
+    private String userRole;
+}

--- a/server-quota/src/main/java/com/o1b4/serverquota/repository/UserRepository.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserByUserId(long userId);
 
     Boolean existsByUserEmail(String email);
+
+    Optional<User> findUserByUserEmail(String email);
 }

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
@@ -1,11 +1,14 @@
 package com.o1b4.serverquota.service;
 
 import com.o1b4.serverquota.dto.request.CreateTeamDTO;
+import com.o1b4.serverquota.dto.request.InvitationDTO;
+import com.o1b4.serverquota.dto.response.InvitedUserDTO;
 import com.o1b4.serverquota.dto.response.MainTeamDTO;
 import com.o1b4.serverquota.dto.response.RolelessMainTeamDTO;
 import com.o1b4.serverquota.dto.response.TeamMemberDTO;
 import com.o1b4.serverquota.entity.BelongTeam;
 import com.o1b4.serverquota.entity.Team;
+import com.o1b4.serverquota.entity.User;
 import com.o1b4.serverquota.entity.UserRole;
 import com.o1b4.serverquota.exception.CustomApiException;
 import com.o1b4.serverquota.repository.BelongTeamRepository;
@@ -133,5 +136,24 @@ public class TeamService {
                 .build();
 
         belongTeamRepository.save(belongTeam);
+    }
+
+    @Transactional
+    public UserRole teamInvitation(InvitationDTO invitation) {
+
+        User user = userRepository.findUserByUserEmail(invitation.getEmail())
+                .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "해당 이메일의 회원은 없습니다."));
+
+        UserRole role = invitation.isAdvisor() ? UserRole.ADVISOR : UserRole.MEMBER;
+
+        BelongTeam belongTeam = BelongTeam.builder()
+                                .teamId(invitation.getTeamId())
+                                .userId(user.getUserId())
+                                .userRole(role)
+                                .build();
+
+            BelongTeam belong = belongTeamRepository.save(belongTeam);
+
+            return belong.getUserRole();
     }
 }


### PR DESCRIPTION
이메일, 초대하려는 팀 ID, Advisor 여부

### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
ex) feat/invite_user_by_email -> main

### issue


### ❓ 변경 사항
팀 초대
(초대하려는 team ID, 해당 유저의 email 주소, advisor 여부)

### 🧪 테스트 결과
#### request
```JSON
{
    "teamId" : 22225,
    "email" : "aaaa@gmail.com",
    "advisor" : "false"
}
```
#### response
```JSON
{
    "httpStatus": "OK",
    "message": "유저 초대 성공",
    "results": null
}
```
#### DB 반영 결과
![image](https://github.com/O1B4/Server-Quota/assets/114378724/ae7f53ce-7ad8-420f-b1d3-c0e9db312140)

![image](https://github.com/O1B4/Server-Quota/assets/114378724/0fb4c496-2a98-4735-b1c7-31e56efa0afb)

