### PR TITLE
[fix] teamId로 team 정보 + ID 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/RolelessMainTeamDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/RolelessMainTeamDTO.java
@@ -8,7 +8,8 @@ import lombok.*;
 @NoArgsConstructor
 public class RolelessMainTeamDTO {
 
-    // main page의 이름, 프로필 사진, url
+    // main page의 이름, 프로필 사진, url, teamID
+    private Long teamId;
 
     private String teamName;
 
@@ -17,7 +18,8 @@ public class RolelessMainTeamDTO {
     private String teamUrl;
 
     @Builder
-    public RolelessMainTeamDTO(String teamName, String teamProfileImage, String teamUrl, String role) {
+    public RolelessMainTeamDTO(Long teamId, String teamName, String teamProfileImage, String teamUrl) {
+        this.teamId = teamId;
         this.teamName = teamName;
         this.teamProfileImage = teamProfileImage;
         this.teamUrl = teamUrl;

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
@@ -100,6 +100,7 @@ public class TeamService {
                 .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "해당 팀은 조회되지 않습니다."));
 
         return RolelessMainTeamDTO.builder()
+                .teamId(team.getTeamId())
                 .teamName(team.getTeamName())
                 .teamProfileImage(team.getTeamProfileImage())
                 .teamUrl(team.getTeamUrl())


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
fix/find_team_info_and_team_id_by_team_id -> main

### ❓ 변경 사항
teamID로 team 정보 조회 시 teamID도 같이 나오게 추가

### 🧪 테스트 결과
```JSON
{
    "httpStatus": 200,
    "message": "조회 성공",
    "results": {
        "team": {
            "teamId": 11111,
            "teamName": "O1B4",
            "teamProfileImage": "String",
            "teamUrl": "team1"
        }
    }
}
```
