### PR TITLE
[fix] teamID로 팀원 정보 + userID 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/TeamMemberDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/TeamMemberDTO.java
@@ -8,12 +8,15 @@ import lombok.*;
 @NoArgsConstructor
 public class TeamMemberDTO {
 
+    private Long userId;
+
     private String userName;
 
     private String userProfileImage;
 
     @Builder
-    public TeamMemberDTO(String userName, String userProfileImage) {
+    public TeamMemberDTO(Long userId, String userName, String userProfileImage) {
+        this.userId = userId;
         this.userName = userName;
         this.userProfileImage = userProfileImage;
     }

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/TeamService.java
@@ -55,6 +55,7 @@ public class TeamService {
         return belongTeams.stream()
                 .map(
                         belongTeam -> TeamMemberDTO.builder()
+                        .userId(belongTeam.getUserId())
                         .userName(
                                 userRepository.findUserByUserId(belongTeam.getUserId())
                                 .orElseThrow(() -> new CustomApiException(HttpStatus.NOT_FOUND, "회원을 조회할 수 없습니다."))


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
fix/find_team_mates_info_and_user_id_by_team_id -> main

### ❓ 변경 사항
teamID로 팀원들 정보 조회 시 각각의 userID도 같이 나오게끔 추가

### 🧪 테스트 결과
```JSON
{
    "httpStatus": 200,
    "message": "조회 성공",
    "results": {
        "teamMembers": [
            {
                "userId": 3,
                "userName": "바뀐 이름입니다.3",
                "userProfileImage": "바뀐 프로필입니다.3"
            },
            {
                "userId": 1234567,
                "userName": "quotiume",
                "userProfileImage": "image1address11111"
            }
        ]
    }
}
```
