### PR TITLE
[fix] teamID로 해당 팀의 예약 룸들 정보 + roomID 조회

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/MainReservationRoomDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/MainReservationRoomDTO.java
@@ -11,6 +11,8 @@ import java.time.LocalDate;
 @ToString
 public class MainReservationRoomDTO {
 
+    private Long roomId;
+
     private String roomName;
 
     private String durationKind;
@@ -30,7 +32,8 @@ public class MainReservationRoomDTO {
     private String roomUrl;
 
     @Builder
-    public MainReservationRoomDTO(String roomName, String durationKind, int duration, String meetingKind, String userName, String userProfileImage, LocalDate rangeStart, LocalDate rangeEnd, String roomUrl) {
+    public MainReservationRoomDTO(Long roomId, String roomName, String durationKind, int duration, String meetingKind, String userName, String userProfileImage, LocalDate rangeStart, LocalDate rangeEnd, String roomUrl) {
+        this.roomId = roomId;
         this.roomName = roomName;
         this.durationKind = durationKind;
         this.duration = duration;

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/RoomService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/RoomService.java
@@ -42,6 +42,7 @@ public class RoomService {
         // list에 해당하는 room들 DTO 매핑
         return rooms.stream()
                 .map(room -> MainReservationRoomDTO.builder()
+                        .roomId(room.getRoomId())
                         .roomName(room.getRoomName())
                         .durationKind(String.valueOf(room.getDurationKind()))
                         .duration(room.getDuration())


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
fix/find_reservations_info_and_id_by_team_id -> main

### ❓ 변경 사항
teamID로 해당 팀의 예약 룸들 정보 조회 시 각각의 roomID도 같이 나오게끔 추가

### 🧪 테스트 결과
```JSON
{
    "httpStatus": 200,
    "message": "조회 성공",
    "results": {
        "reservationRooms": [
            {
                "roomId": 1,
                "roomName": "first 예약 룸",
                "durationKind": "HOUR",
                "duration": 1,
                "meetingKind": "직접 만나기",
                "userName": "quotiume",
                "userProfileImage": "image1address11111",
                "rangeStart": "2023-10-23",
                "rangeEnd": "2023-10-26",
                "roomUrl": "firstRoomUrl"
            }
     ]
}
```
