### PR TITLE
[fix] roomID로 특정 룸으로 예약된 예약 정보 모두 보기 + reservId 추가

### DIFF
--- a/server-quota/src/main/java/com/o1b4/serverquota/dto/response/ReservationDTO.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/dto/response/ReservationDTO.java
@@ -11,6 +11,8 @@ import java.time.LocalTime;
 @NoArgsConstructor
 public class ReservationDTO {
 
+    private Long reservId;
+
     private LocalDate reservDate;
 
     private LocalTime reservTime;
@@ -24,10 +26,11 @@ public class ReservationDTO {
     private String reservMemo;
 
     @Builder
-    public ReservationDTO(String userName, LocalDate reservDate, LocalTime reservTime, String reservName, String reservEmail, String reservMemo) {
-        this.userName = userName;
+    public ReservationDTO(Long reservId, LocalDate reservDate, LocalTime reservTime, String userName, String reservName, String reservEmail, String reservMemo) {
+        this.reservId = reservId;
         this.reservDate = reservDate;
         this.reservTime = reservTime;
+        this.userName = userName;
         this.reservName = reservName;
         this.reservEmail = reservEmail;
         this.reservMemo = reservMemo;

--- a/server-quota/src/main/java/com/o1b4/serverquota/service/ReservationService.java
+++ b/server-quota/src/main/java/com/o1b4/serverquota/service/ReservationService.java
@@ -51,6 +51,7 @@ public class ReservationService {
         return reservations.stream()
                 .map(
                         reservation -> ReservationDTO.builder()
+                                .reservId(reservation.getReservId())
                                 .reservDate(reservation.getReservDate())
                                 .reservTime(reservation.getReservTime())
                                 .reservEmail(reservation.getReservEmail())


### PR DESCRIPTION
### ⚙️ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌳 반영 브랜치
fix/get_reservations_info_and_reserv_id_by_room_id -> main

### ❓ 변경 사항
roomID로 특정 룸으로 예약된 예약들 정보 조회 시 각각의 reservId도 같이 나오게끔 추가

### 🧪 테스트 결과
```JSON
{
    "httpStatus": 200,
    "message": "조회 성공",
    "results": {
        "reservations": [
            {
                "reservId": 1,
                "reservDate": "2023-01-01",
                "reservTime": "11:00:00",
                "userName": "quotiume",
                "reservName": "예약 이름 1",
                "reservEmail": "aaa@gmail.com 설명란에 적어놓은 email",
                "reservMemo": "예약 설명 1"
            },
            {
                "reservId": 2,
                "reservDate": "2023-11-11",
                "reservTime": "13:00:00",
                "userName": "바뀐 이름입니다.3",
                "reservName": "예약 이름 2",
                "reservEmail": "aadsaa@gmail.com 설명란에 적어놓은 email",
                "reservMemo": "예약 설명 2"
            }
        ]
    }
}
```
